### PR TITLE
Added side menu to all pages

### DIFF
--- a/src/app/cars/page.tsx
+++ b/src/app/cars/page.tsx
@@ -22,8 +22,8 @@ export default function CarsPage() {
   const handleResize = () => {
     const newWindowDimensions = {
       width: window.innerWidth,
-      height: window.innerHeight
-    }
+      height: window.innerHeight,
+    };
 
     setWindowHeight(newWindowDimensions.height);
     setWindowWidth(newWindowDimensions.width);
@@ -44,7 +44,7 @@ export default function CarsPage() {
             top: "0",
             right: "0",
             bottom: "0",
-            left: "0"
+            left: "0",
           }}
         />
       )}

--- a/src/app/cars/page.tsx
+++ b/src/app/cars/page.tsx
@@ -1,23 +1,54 @@
+"use client";
+
 import Footer from "@/components/footer";
 import Header from "@/components/header";
 import Car from "@/components/car";
+import SideMenu from "@/components/sidebar";
+import { useEffect, useState } from "react";
 
-export default function MediaPage() {
+export default function CarsPage() {
+  const [windowHeight, setWindowHeight] = useState(0);
+  const [windowWidth, setWindowWidth] = useState(0);
+  const breakpoint = 1024;
+
+  useEffect(() => {
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  const handleResize = () => {
+    const newWindowDimensions = {
+      width: window.innerWidth,
+      height: window.innerHeight
+    }
+
+    setWindowHeight(newWindowDimensions.height);
+    setWindowWidth(newWindowDimensions.width);
+  };
+
   return (
     <main className="">
-      <Header
-        selectedPage={4}
-        className=""
-        style={{
-          background: "rgba(0,0,0)",
-          position: "fixed",
-          zIndex: 1,
-          top: "0",
-          right: "0",
-          bottom: "0",
-          left: "0",
-        }}
-      />
+      {windowWidth < breakpoint ? (
+        <SideMenu className="" />
+      ) : (
+        <Header
+          selectedPage={4}
+          className=""
+          style={{
+            background: "rgba(0,0,0)",
+            position: "fixed",
+            zIndex: 1,
+            top: "0",
+            right: "0",
+            bottom: "0",
+            left: "0"
+          }}
+        />
+      )}
+
       <div
         className=""
         style={{

--- a/src/app/media/page.tsx
+++ b/src/app/media/page.tsx
@@ -58,8 +58,8 @@ export default function MediaPage() {
   const handleResize = () => {
     const newWindowDimensions = {
       width: window.innerWidth,
-      height: window.innerHeight
-    }
+      height: window.innerHeight,
+    };
 
     setWindowHeight(newWindowDimensions.height);
     setWindowWidth(newWindowDimensions.width);
@@ -80,7 +80,7 @@ export default function MediaPage() {
             top: "0",
             right: "0",
             bottom: "0",
-            left: "0"
+            left: "0",
           }}
         />
       )}

--- a/src/app/media/page.tsx
+++ b/src/app/media/page.tsx
@@ -1,7 +1,11 @@
+"use client";
+
 import Footer from "@/components/footer";
 import Header from "@/components/header";
+import SideMenu from "@/components/sidebar";
 import ImageCard from "@/components/image-card";
 import { motion } from "framer-motion";
+import { useEffect, useState } from "react";
 
 const images = [
   {
@@ -39,21 +43,48 @@ const images = [
 ];
 
 export default function MediaPage() {
+  const [windowHeight, setWindowHeight] = useState(0);
+  const [windowWidth, setWindowWidth] = useState(0);
+  const breakpoint = 1024;
+
+  useEffect(() => {
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  const handleResize = () => {
+    const newWindowDimensions = {
+      width: window.innerWidth,
+      height: window.innerHeight
+    }
+
+    setWindowHeight(newWindowDimensions.height);
+    setWindowWidth(newWindowDimensions.width);
+  };
+
   return (
     <main className="">
-      <Header
-        selectedPage={3}
-        className=""
-        style={{
-          background: "rgba(0,0,0)",
-          position: "fixed",
-          zIndex: 1,
-          top: "0",
-          right: "0",
-          bottom: "0",
-          left: "0",
-        }}
-      />
+      {windowWidth < breakpoint ? (
+        <SideMenu className="" />
+      ) : (
+        <Header
+          selectedPage={3}
+          className=""
+          style={{
+            background: "rgba(0,0,0)",
+            position: "fixed",
+            zIndex: 1,
+            top: "0",
+            right: "0",
+            bottom: "0",
+            left: "0"
+          }}
+        />
+      )}
+
       <div
         className=""
         style={{

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,9 +30,11 @@ export default function HomePage() {
   const [windowWidth, setWindowWidth] = useState(0);
   const [calcWidth, setCalcWidth] = useState(0);
   const [scrollY, setScrollY] = useState(0);
-  const breakpoint = 950;
+  const breakpoint = 1024;
 
   useEffect(() => {
+    handleScroll();
+    handleResize();
     window.addEventListener("scroll", handleScroll);
     window.addEventListener("resize", handleResize);
     return () => {

--- a/src/app/sponsors/page.tsx
+++ b/src/app/sponsors/page.tsx
@@ -24,8 +24,8 @@ export default function SponsorsPage() {
   const handleResize = () => {
     const newWindowDimensions = {
       width: window.innerWidth,
-      height: window.innerHeight
-    }
+      height: window.innerHeight,
+    };
 
     setWindowHeight(newWindowDimensions.height);
     setWindowWidth(newWindowDimensions.width);
@@ -46,7 +46,7 @@ export default function SponsorsPage() {
             top: "0",
             right: "0",
             bottom: "0",
-            left: "0"
+            left: "0",
           }}
         />
       )}
@@ -62,7 +62,9 @@ export default function SponsorsPage() {
       >
         <div className="bg-black bg-opacity-30 p-8">
           <div className="mt-16 flex flex-col items-center justify-center text-center text-white lg:mb-48 lg:ml-64 lg:mr-64 lg:mt-64">
-            <h1 className="p-16" style={{textAlign: "center"}}>OUR SPONSORS</h1>
+            <h1 className="p-16" style={{ textAlign: "center" }}>
+              OUR SPONSORS
+            </h1>
           </div>
         </div>
       </div>
@@ -76,12 +78,15 @@ export default function SponsorsPage() {
         }}
       >
         <div className="bg-black bg-opacity-70 p-16">
-          <div className="flex flex-col items-center justify-center text-white text-center lg:mx-16 lg:mb-32">
+          <div className="flex flex-col items-center justify-center text-center text-white lg:mx-16 lg:mb-32">
             <h2 className="m-16 text-center">PLATINUM &nbsp;SPONSORS</h2>
             {/* 1st row of platinum sponsors */}
             <div className="mx-auto grid w-full max-w-screen-lg grid-cols-1 gap-8 lg:grid-cols-2">
               <div className="flex flex-col items-center">
-                <div className="flex h-48 flex-col items-center justify-center" style={{paddingBottom: "2vh"}}>
+                <div
+                  className="flex h-48 flex-col items-center justify-center"
+                  style={{ paddingBottom: "2vh" }}
+                >
                   <Image
                     className="m-2 lg:m-4"
                     src="/logo/sponsor/2024/asfinance-logo-white.png"
@@ -406,9 +411,12 @@ export default function SponsorsPage() {
         </div>
       </div>
       <div className="bg-black bg-opacity-70">
-        <div className="flex flex-col items-center justify-center text-white text-center lg:mb-32 lg:ml-32 lg:mr-32 lg:mt-16">
+        <div className="flex flex-col items-center justify-center text-center text-white lg:mb-32 lg:ml-32 lg:mr-32 lg:mt-16">
           <h1 className="p-8">SPONSOR US</h1>
-          <p className="text-xl" style={{paddingLeft: "3rem", paddingRight: "3rem"}}>
+          <p
+            className="text-xl"
+            style={{ paddingLeft: "3rem", paddingRight: "3rem" }}
+          >
             We'd love to have you as a sponsor! Whether it is fueling us with
             pizza, supplying us with materials, or just throwing some cash our
             way, your donations are crucial to making this all possible! If you

--- a/src/app/sponsors/page.tsx
+++ b/src/app/sponsors/page.tsx
@@ -1,25 +1,56 @@
+"use client";
+
 import Footer from "../../components/footer";
 import Header from "../../components/header";
+import SideMenu from "../../components/sidebar";
 import { OutlineButton } from "@/components/ui/outline-button";
 import Image from "next/image";
 import Link from "next/link";
+import { useEffect, useState } from "react";
 
 export default function SponsorsPage() {
+  const [windowHeight, setWindowHeight] = useState(0);
+  const [windowWidth, setWindowWidth] = useState(0);
+  const breakpoint = 1024;
+
+  useEffect(() => {
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  const handleResize = () => {
+    const newWindowDimensions = {
+      width: window.innerWidth,
+      height: window.innerHeight
+    }
+
+    setWindowHeight(newWindowDimensions.height);
+    setWindowWidth(newWindowDimensions.width);
+  };
+
   return (
     <main className="overflow-hidden">
-      <Header
-        selectedPage={5}
-        className=""
-        style={{
-          background: "rgba(0,0,0)",
-          position: "fixed",
-          zIndex: 1,
-          top: "0",
-          right: "0",
-          bottom: "0",
-          left: "0",
-        }}
-      />
+      {windowWidth < breakpoint ? (
+        <SideMenu className="" />
+      ) : (
+        <Header
+          selectedPage={5}
+          className=""
+          style={{
+            background: "rgba(0,0,0)",
+            position: "fixed",
+            zIndex: 1,
+            top: "0",
+            right: "0",
+            bottom: "0",
+            left: "0"
+          }}
+        />
+      )}
+
       <div
         className=""
         style={{
@@ -29,9 +60,9 @@ export default function SponsorsPage() {
           backgroundRepeat: "no-repeat",
         }}
       >
-        <div className="bg-black bg-opacity-30 p-16">
+        <div className="bg-black bg-opacity-30 p-8">
           <div className="mt-16 flex flex-col items-center justify-center text-center text-white lg:mb-48 lg:ml-64 lg:mr-64 lg:mt-64">
-            <h1 className="p-16">OUR SPONSORS</h1>
+            <h1 className="p-16" style={{textAlign: "center"}}>OUR SPONSORS</h1>
           </div>
         </div>
       </div>
@@ -45,12 +76,12 @@ export default function SponsorsPage() {
         }}
       >
         <div className="bg-black bg-opacity-70 p-16">
-          <div className="mx-8 flex flex-col items-center justify-center text-white lg:mx-16 lg:mb-32">
+          <div className="flex flex-col items-center justify-center text-white text-center lg:mx-16 lg:mb-32">
             <h2 className="m-16 text-center">PLATINUM &nbsp;SPONSORS</h2>
             {/* 1st row of platinum sponsors */}
             <div className="mx-auto grid w-full max-w-screen-lg grid-cols-1 gap-8 lg:grid-cols-2">
               <div className="flex flex-col items-center">
-                <div className="flex h-48 flex-col items-center justify-center">
+                <div className="flex h-48 flex-col items-center justify-center" style={{paddingBottom: "2vh"}}>
                   <Image
                     className="m-2 lg:m-4"
                     src="/logo/sponsor/2024/asfinance-logo-white.png"
@@ -374,10 +405,10 @@ export default function SponsorsPage() {
           </div>
         </div>
       </div>
-      <div className="bg-black bg-opacity-70 p-16">
-        <div className="flex flex-col items-center justify-center text-white lg:mb-32 lg:ml-64 lg:mr-64 lg:mt-16">
-          <h1 className="p-16">SPONSOR US</h1>
-          <p className="text-xl">
+      <div className="bg-black bg-opacity-70">
+        <div className="flex flex-col items-center justify-center text-white text-center lg:mb-32 lg:ml-32 lg:mr-32 lg:mt-16">
+          <h1 className="p-8">SPONSOR US</h1>
+          <p className="text-xl" style={{paddingLeft: "3rem", paddingRight: "3rem"}}>
             We'd love to have you as a sponsor! Whether it is fueling us with
             pizza, supplying us with materials, or just throwing some cash our
             way, your donations are crucial to making this all possible! If you

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -31,8 +31,8 @@ export default function TeamPage() {
   const handleResize = () => {
     const newWindowDimensions = {
       width: window.innerWidth,
-      height: window.innerHeight
-    }
+      height: window.innerHeight,
+    };
 
     setWindowHeight(newWindowDimensions.height);
     setWindowWidth(newWindowDimensions.width);
@@ -53,7 +53,7 @@ export default function TeamPage() {
             top: "0",
             right: "0",
             bottom: "0",
-            left: "0"
+            left: "0",
           }}
         />
       )}
@@ -69,13 +69,20 @@ export default function TeamPage() {
       >
         <div className="bg-black bg-opacity-30 p-16">
           <div className="mt-16 flex flex-col items-center justify-center text-white lg:mb-48 lg:ml-64 lg:mr-64 lg:mt-64">
-            <h1 className="p-16" style={{textAlign: "center"}}>OUR TEAM</h1>
+            <h1 className="p-16" style={{ textAlign: "center" }}>
+              OUR TEAM
+            </h1>
           </div>
         </div>
       </div>
       <div className="bg-black bg-opacity-70 p-8">
         <div className="flex flex-col items-center text-white">
-          <h1 className="mb-16 mt-16 lg:ml-64 lg:mr-64" style={{textAlign: "center"}}>OFFICERS</h1>
+          <h1
+            className="mb-16 mt-16 lg:ml-64 lg:mr-64"
+            style={{ textAlign: "center" }}
+          >
+            OFFICERS
+          </h1>
           <div className="flex flex-wrap justify-center lg:ml-16 lg:mr-16">
             <TeamCard
               name="Thomas Yu"
@@ -124,7 +131,12 @@ export default function TeamPage() {
       </div>
       <div className="bg-black bg-opacity-70 p-8">
         <div className="flex flex-col items-center text-white">
-          <h1 className="mb-16 mt-16 lg:ml-64 lg:mr-64" style={{textAlign: "center"}}>TEAM LEADS</h1>
+          <h1
+            className="mb-16 mt-16 lg:ml-64 lg:mr-64"
+            style={{ textAlign: "center" }}
+          >
+            TEAM LEADS
+          </h1>
           <div className="flex flex-wrap items-stretch justify-center lg:ml-16 lg:mr-16">
             <TeamCard
               name="Alex Fu"
@@ -222,7 +234,7 @@ export default function TeamPage() {
                           lg:mb-32 lg:ml-64 lg:mr-64 lg:mt-16"
           >
             <h1 className="p-16">ALUMNI</h1>
-            <p className="" style={{textAlign: "center"}}>
+            <p className="" style={{ textAlign: "center" }}>
               At Gaucho Racing, we are proud of the legacy built by our alumni.
               Over the years, countless students have contributed their passion,
               skills, and dedication to our team, driving innovation and
@@ -231,7 +243,7 @@ export default function TeamPage() {
               leadership.
             </p>
             <br />
-            <p className="" style={{textAlign: "center"}}>
+            <p className="" style={{ textAlign: "center" }}>
               Stay connected, share your journey, and continue to be a part of
               the Gaucho Racing family. Your experiences and success stories
               inspire the next generation of Gaucho Racing members.

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import Footer from "@/components/footer";
 import Header from "@/components/header";
+import SideMenu from "@/components/sidebar";
 import { OutlineButton } from "@/components/ui/outline-button";
 import {
   Card,
@@ -9,24 +12,52 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import TeamCard from "@/components/team-card";
+import { useEffect, useState } from "react";
 import placeholderImage from "src/assets/images/placeholder-profile.png";
 
 export default function TeamPage() {
+  const [windowHeight, setWindowHeight] = useState(0);
+  const [windowWidth, setWindowWidth] = useState(0);
+  const breakpoint = 1024;
+
+  useEffect(() => {
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  const handleResize = () => {
+    const newWindowDimensions = {
+      width: window.innerWidth,
+      height: window.innerHeight
+    }
+
+    setWindowHeight(newWindowDimensions.height);
+    setWindowWidth(newWindowDimensions.width);
+  };
+
   return (
     <main className="">
-      <Header
-        selectedPage={2}
-        className=""
-        style={{
-          background: "rgba(0,0,0)",
-          position: "fixed",
-          zIndex: 1,
-          top: "0",
-          right: "0",
-          bottom: "0",
-          left: "0",
-        }}
-      />
+      {windowWidth < breakpoint ? (
+        <SideMenu className="" />
+      ) : (
+        <Header
+          selectedPage={2}
+          className=""
+          style={{
+            background: "rgba(0,0,0)",
+            position: "fixed",
+            zIndex: 1,
+            top: "0",
+            right: "0",
+            bottom: "0",
+            left: "0"
+          }}
+        />
+      )}
+
       <div
         className=""
         style={{
@@ -38,13 +69,13 @@ export default function TeamPage() {
       >
         <div className="bg-black bg-opacity-30 p-16">
           <div className="mt-16 flex flex-col items-center justify-center text-white lg:mb-48 lg:ml-64 lg:mr-64 lg:mt-64">
-            <h1 className="p-16">OUR TEAM</h1>
+            <h1 className="p-16" style={{textAlign: "center"}}>OUR TEAM</h1>
           </div>
         </div>
       </div>
       <div className="bg-black bg-opacity-70 p-8">
         <div className="flex flex-col items-center text-white">
-          <h1 className="mb-16 mt-16 lg:ml-64 lg:mr-64">OFFICERS</h1>
+          <h1 className="mb-16 mt-16 lg:ml-64 lg:mr-64" style={{textAlign: "center"}}>OFFICERS</h1>
           <div className="flex flex-wrap justify-center lg:ml-16 lg:mr-16">
             <TeamCard
               name="Thomas Yu"
@@ -93,7 +124,7 @@ export default function TeamPage() {
       </div>
       <div className="bg-black bg-opacity-70 p-8">
         <div className="flex flex-col items-center text-white">
-          <h1 className="mb-16 mt-16 lg:ml-64 lg:mr-64">TEAM LEADS</h1>
+          <h1 className="mb-16 mt-16 lg:ml-64 lg:mr-64" style={{textAlign: "center"}}>TEAM LEADS</h1>
           <div className="flex flex-wrap items-stretch justify-center lg:ml-16 lg:mr-16">
             <TeamCard
               name="Alex Fu"
@@ -190,8 +221,8 @@ export default function TeamPage() {
             className="flex flex-col items-center justify-center text-white 
                           lg:mb-32 lg:ml-64 lg:mr-64 lg:mt-16"
           >
-            <h1 className="p-16">Alumni</h1>
-            <p className="">
+            <h1 className="p-16">ALUMNI</h1>
+            <p className="" style={{textAlign: "center"}}>
               At Gaucho Racing, we are proud of the legacy built by our alumni.
               Over the years, countless students have contributed their passion,
               skills, and dedication to our team, driving innovation and
@@ -200,7 +231,7 @@ export default function TeamPage() {
               leadership.
             </p>
             <br />
-            <p className="">
+            <p className="" style={{textAlign: "center"}}>
               Stay connected, share your journey, and continue to be a part of
               the Gaucho Racing family. Your experiences and success stories
               inspire the next generation of Gaucho Racing members.

--- a/src/components/ui/outline-button.tsx
+++ b/src/components/ui/outline-button.tsx
@@ -16,8 +16,10 @@ const OutlineButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
             "group relative mb-2 me-2 mt-8 inline-flex items-center justify-center rounded-lg bg-gradient-to-br from-gr-pink to-gr-purple p-0.5 text-lg font-bold text-white",
           )}
         >
-          <span className="relative h-11 rounded-md bg-black px-8 py-2.5 transition-all duration-75 ease-in group-hover:bg-opacity-0"
-          style={{width: "fit-content", height: "fit-content"}}>
+          <span
+            className="relative h-11 rounded-md bg-black px-8 py-2.5 transition-all duration-75 ease-in group-hover:bg-opacity-0"
+            style={{ width: "fit-content", height: "fit-content" }}
+          >
             {props.children}
           </span>
         </button>

--- a/src/components/ui/outline-button.tsx
+++ b/src/components/ui/outline-button.tsx
@@ -13,10 +13,11 @@ const OutlineButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
           ref={ref}
           className={cn(
             className,
-            "group relative mb-2 me-2 mt-8 inline-flex items-center justify-center overflow-hidden rounded-lg bg-gradient-to-br from-gr-pink to-gr-purple p-0.5 text-lg font-bold text-white",
+            "group relative mb-2 me-2 mt-8 inline-flex items-center justify-center rounded-lg bg-gradient-to-br from-gr-pink to-gr-purple p-0.5 text-lg font-bold text-white",
           )}
         >
-          <span className="relative h-11 rounded-md bg-black px-8 py-2.5 transition-all duration-75 ease-in group-hover:bg-opacity-0">
+          <span className="relative h-11 rounded-md bg-black px-8 py-2.5 transition-all duration-75 ease-in group-hover:bg-opacity-0"
+          style={{width: "fit-content", height: "fit-content"}}>
             {props.children}
           </span>
         </button>


### PR DESCRIPTION
Side menu is now activated on all pages if the screen width is less than 1024px. Previously, it was only integrated into the home/about page and activated if the screen width was less than 950px. Also fixed outline buttons so that they no longer hide overflow and instead accommodate for the text box size.